### PR TITLE
fix(#19): calculate match_score on backend to prevent spoofing

### DIFF
--- a/server/history/router.py
+++ b/server/history/router.py
@@ -7,6 +7,7 @@ from . import models as history_models
 from server.database import get_db
 from server.auth.deps import get_current_active_user
 from server.auth import models as auth_models
+from server.extraction.engine import calculate_match_score
 
 router = APIRouter()
 
@@ -33,8 +34,11 @@ def create_history(
     """
     Create a new analysis history record for the current authenticated user.
     """
+    match_score = calculate_match_score(history_in.have_skills, history_in.missing_skills)
+
     db_history = history_models.AnalysisHistory(
         user_id=current_user.id,
+        match_score=match_score,
         **history_in.model_dump()
     )
     db.add(db_history)

--- a/server/history/schemas.py
+++ b/server/history/schemas.py
@@ -5,7 +5,6 @@ from datetime import datetime
 class HistoryBase(BaseModel):
     company_name: Optional[str] = None
     position_name: Optional[str] = None
-    match_score: float = Field(..., ge=0, le=100)
     have_skills: List[str]
     missing_skills: List[str]
     bonus_skills: List[str]
@@ -20,6 +19,7 @@ class HistoryUpdate(BaseModel):
 class HistoryResponse(HistoryBase):
     id: int
     user_id: int
+    match_score: float = Field(..., ge=0, le=100)
     date_analyzed: datetime
 
     class Config:

--- a/server/tests/test_history.py
+++ b/server/tests/test_history.py
@@ -31,7 +31,6 @@ def test_create_history():
     response = client.post("/api/history/", json={
         "company_name": "ACME",
         "position_name": "Engineer",
-        "match_score": 85.5,
         "have_skills": ["python"],
         "missing_skills": ["aws"],
         "bonus_skills": []
@@ -40,7 +39,7 @@ def test_create_history():
     assert response.status_code == 200
     data = response.json()
     assert data["company_name"] == "ACME"
-    assert data["match_score"] == 85.5
+    assert data["match_score"] == 50.0
     assert len(mock_db.adds) == 1
 
 def test_get_history():


### PR DESCRIPTION
This PR addresses a security vulnerability where match_score was blindly trusted directly from the client request payload during history creation. The backend now securely calculates the score server-side using the internal `Extraction Engine` before storing it in the database.